### PR TITLE
Changed constant "ARRAY_LENGTH" from uint8_t to uint16_t

### DIFF
--- a/SleepSurLeKeyboard.cpp
+++ b/SleepSurLeKeyboard.cpp
@@ -19,7 +19,7 @@ int main()
 
 	const uint8_t FUNC_NUMBER = 8;
 	const uint8_t FUNC_NUM_MID = FUNC_NUMBER / 2;
-	const uint8_t ARRAY_LENGTH = 10000;
+	const uint16_t ARRAY_LENGTH = 10000;
 	const uint16_t last_instr = 0;
 
 	uint8_t bit_ptr = 0;


### PR DESCRIPTION
Changed constant "ARRAY_LENGTH" from uint8_t to uint16_t because of the uint8_t size which is to limited.